### PR TITLE
Use the geospaas slim image as base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: shell
 services:
   - docker
 
-if: type = push OR tag IS present
+if: type = push
 env:
   global:
     - IMAGE_NAME="${DOCKER_ORG}/geospaas_uwsgi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: shell
 services:
   - docker
 
-if: type = pull_request OR tag IS present
+if: type = push OR tag IS present
 env:
   global:
     - IMAGE_NAME="${DOCKER_ORG}/geospaas_uwsgi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM nansencenter/geospaas:1.2.0
+FROM nansencenter/geospaas:2.0.0-slim
 
-# The pip version of uwsgi is not compatible with the conda Python version used in geospaas
-RUN conda install uwsgi
+RUN apt update && \
+    apt install -y gcc && \
+    # Disable LTO optimization because the LTO versions from the standard
+    # debian buster GCC and the version of GCC used by Anaconda are different
+    LDFLAGS='-fno-lto' pip install uwsgi && \
+    apt remove -y gcc && \
+    apt clean && apt autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/geospaas-app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM nansencenter/geospaas:2.0.0-slim
 
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${VIRTUAL_ENV}/lib"
+
 RUN apt update && \
     apt install -y gcc && \
     # Disable LTO optimization because the LTO versions from the standard

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -6,5 +6,6 @@ master = true
 processes = 4
 threads = 2
 stats = 0.0.0.0:9191
+stats-http = true
 static-map = /static=/opt/geospaas-app/static
 log-master = true


### PR DESCRIPTION
Installing uWSGI using pip involves compilation, thus the need for gcc.

It is also necessary to disable [LTO](https://gcc.gnu.org/onlinedocs/gccint/LTO-Overview.html) during this compilation, because the version of Python installed in `/venv ` is built by Anaconda using a specific gcc (thus LTO) version. This LTO version is different from the one used in the standard Debian gcc, which causes an incompatibility.