### PR TITLE
Update geospaas version to 5.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nansencenter/geospaas:2.4.0-slim
+FROM nansencenter/geospaas:2.5.1-slim
 
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${VIRTUAL_ENV}/lib"
 

--- a/geospaas_web/settings.py
+++ b/geospaas_web/settings.py
@@ -140,3 +140,4 @@ SESSION_COOKIE_SECURE = True
 SECURE_SSL_REDIRECT = True
 
 # Extra settings
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
- Update geospaas image version to 5.2.1
- Add DEFAULT_AUTO_FIELD setting necessary after the django 3.2 upgrade
FYI @akorosov 