### PR TITLE
Use geospaas 2.5.4 as base image

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     env:
       latest: ${{ matrix.python_version == '3.11' && 'true' || '' }}
-      BASE_IMAGE: "${{ vars.DOCKER_ORG }}/geospaas:2.5.2-python${{ matrix.python_version }}"
+      BASE_IMAGE: "${{ vars.DOCKER_ORG }}/geospaas:2.5.4-python${{ matrix.python_version }}"
     strategy:
       matrix:
         python_version:


### PR DESCRIPTION
django-geo-spaas 2.5.4 contains:
- updates to the doc
- updates to the package requiremetns
- deleted use of deprecated function